### PR TITLE
Fixed handling of command argument to allow quotes in command

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports.templateTags = [
         displayName: 'Command/shell to be executed',
         help: 'Executes the given command using require("child_process").exec command',
         type: 'string',
+        encoding: 'base64',
       }
     ],
     async run(context, type = 'string', cmd) {

--- a/insomnia-plugin-sh-cmd.code-workspace
+++ b/insomnia-plugin-sh-cmd.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insomnia-plugin-sh-cmd",
   
-  "version": "0.0.1",
+  "version": "0.0.2",
 
   "author": "Mageshwaran Rajendran <mageshwaranr@gmail.com>",
 


### PR DESCRIPTION
I noticed that this plugin breaks whenever you try to use any type of quotes in the command, which is required to use commands like sed and awk.

I thought I'd scratch my own itch here and then contribute the fix upstream.  I'm new to insomnia plugin development, so if there is a better way to accomplish the same thing here, I'm open to feedback, code review, and any improvements.

After merging, are the changes picked up by insomnia automatically or is there a release cycle necessary?

Thanks!